### PR TITLE
update: Quipper を Recruit に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | [Timers](https://timers-inc.com/) | 家族アプリ「Famm」など | [here](https://prtimes.jp/main/html/rd/p/000000035.000037972.html) ||
 |[GMOペパボ](https://pepabo.com/)| ロリポップ！レンタルサーバー、minne、SUZURI など |[here](https://github.com/corocn/paternity-leave-in-japan/pull/18)|[あり](https://recruit.pepabo.com/environment/)|
 | [アイレット](https://www.iret.co.jp/) | ITコンサルティング、システム開発、システム保守・運用、サーバハウジング・ホスティング | [here](https://cloudpack.media/52160) ||
-| [Quipper](https://www.quipper.com/) | スタディサプリ、Quipper | [here](https://quipper.hatenablog.com/entry/2018/10/23/paternity-leave) ||
+| [Recruit](https://www.quipper.com/) | スタディサプリなど | [here](https://quipper.hatenablog.com/entry/2018/10/23/paternity-leave) | [あり](https://recruit-saiyo.jp/benefits/) |
 | [ユーザベース](https://www.uzabase.com/) | NewsPicks、SPEEDA、FORCAS、UB VENTURES など  | [here](https://note.com/kazypinksaurus/n/nca17d51808fd) | [あり](https://www.uzabase.com/jp/careers/) |
 | [Sansan](https://jp.corp-sansan.com/) | Sansan、Eight、BillOne など  | [here](https://twitter.com/ko_hirayama/status/1387334986877964290?s=20) | [あり](https://jp.corp-sansan.com/recruit/office#systems) |
 | [オープンストリーム](https://www.opst.co.jp/) | Biz/Browser、マルチクラウドによるシステム開発など | [here](https://www.opst.co.jp/activity/detail/report/blog/report200909) ||


### PR DESCRIPTION
会社統合に伴って Quipper という社名がなくなりましたので、更新します。