### PR TITLE
BASE株式会社を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 | [Kyash](https://www.kyash.co/) | デジタルウォレットアプリ[Kyash](https://www.kyash.co/) | [here](https://blog.pranc1ngpegasus.com/entry/2021/08/31/100000) ||
 | [カラクリ](https://karakuri-ai.co.jp/) | カスタマーサポート（CS）領域に特化したAIソリューション[KARAKURI](https://karakuri.ai/) | [here](https://twitter.com/yos1up/status/1400283732070653956) ||
 | [Leaner Technologies](https://leaner.co.jp/) | Leaner見積など | [here](https://zenn.dev/leaner_tech/articles/20211119-paternity_leave) | [あり](https://leaner.co.jp/210913/) |
-
+|[BASE株式会社](https://binc.jp/)|ネットショップ開設実績4年連続No.1のEコマースプラットフォーム「BASE」、オンライン決済サービス「PAY.JP」、ID決済サービス「PAY ID」 を企画・開発・運営|[here](https://devblog.thebase.in/entry/2019/12/01/090000)||
 
 ## Contributing
 


### PR DESCRIPTION
BASE株式会社でも2ヶ月以上の男性育休取得実績があるので、追加させてください。

https://devblog.thebase.in/entry/2019/12/01/090000

> BASEに入社して1年半ほどになります。入社後はWebアプリケーションエンジニアとしてEコマースプラットフォーム「BASE（ベイス）」のバックエンド開発をする傍ら、PJの開発ディレクションやチーム作り・組織作りに取り組んできました。

> 私ごとですが、今年の6月に第一子が生まれました。そして子の誕生に合わせて2ヶ月半の育休を取得しました。


基準を満たさないため参考資料ですが私自身もBASE株式会社で4ヶ月の育休を取得しています。
https://budougumi0617.github.io/2020/12/27/retrospective-2020/
> 育休を4か月取った後、11月から働いている。