### PR TITLE
add: オーバードライブ

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 |[株式会社クラッソーネ](https://www.crassone.co.jp/)|解体工事会社と施主をマッチングする無料一括見積りサービス「[クラッソーネ](https://www.crassone.jp/)」|[here](https://tech.crassone.jp/posts/childcare-leave)||
 |[株式会社CureApp](https://cureapp.co.jp/)|ニコチン依存症や高血圧領域の医療機関向け「[治療アプリ](https://cureapp.co.jp/product.html)」、民間向けのモバイルヘルスプログラム「[ascure](https://cureapp.co.jp/corporations.html)」など|[here](https://zenn.dev/cureapp/articles/e85767d83a3cca)||
 |[株式会社マクアケ](https://www.makuake.co.jp/)|アタラシイものや体験の応援購入サービス「[Makuake](https://www.makuake.com/)」など|[here](https://note.com/dev_makuake/n/n4c71ee15c92f)||
+| [株式会社オーバードライブ](https://corp.hoobby.net/) | ボードゲーム専門の総合情報サイト「[ボドゲーマ](https://bodoge.hoobby.net/)」、ボードゲームに特化したクラウドファンディングサイト「[ボドファン](https://bodofun.hoobby.net/)」など| [here](https://note.com/sakumenx/n/nd39b443b602f) ||
 
 ## Contributing
 


### PR DESCRIPTION
## 企業情報

_ | _
---|---
社名 | 株式会社オーバードライブ
コーポレートサイト | https://corp.hoobby.net/

## 育休取得実績・予定

_ | _ | _
---|---|---
1人目 (実績) | 2022年1月〜2022年4月中旬の約3ヶ月半 | ![image](https://github.com/corocn/paternity-leave-in-japan/assets/33092136/05d0afc5-c257-409e-8d22-2b4fff5cd171)
2人目(予定) | 2024年4月〜2025年5月の1年間 (途中で一次復帰) | ![image](https://github.com/corocn/paternity-leave-in-japan/assets/33092136/17f963b6-e189-4223-ba3d-bce2981d4769)

## 育休取得の資料

- https://note.com/sakumenx/n/nd39b443b602f
- https://twitter.com/sakumenx/status/1720186015451914570